### PR TITLE
do not ingest records with unexpectedly long time spans

### DIFF
--- a/datalake_common/__init__.py
+++ b/datalake_common/__init__.py
@@ -13,12 +13,10 @@
 # the License.
 
 import pyver
+from metadata import Metadata, InvalidDatalakeMetadata, \
+    UnsupportedDatalakeMetadataVersion
+from record import DatalakeRecord, has_s3
 
 __version__, __version_info__ = pyver.get_version(pkg='datalake-common')
 __all__ = ['Metadata', 'InvalidDatalakeMetadata',
            'UnsupportedDatalakeMetadataVersion', 'DatalakeRecord', 'has_s3']
-
-
-from metadata import Metadata, InvalidDatalakeMetadata, \
-    UnsupportedDatalakeMetadataVersion
-from record import DatalakeRecord, has_s3

--- a/datalake_common/errors.py
+++ b/datalake_common/errors.py
@@ -15,3 +15,7 @@
 
 class InsufficientConfiguration(Exception):
     pass
+
+
+class UnsupportedTimeRange(Exception):
+    pass

--- a/datalake_common/tests/test_record.py
+++ b/datalake_common/tests/test_record.py
@@ -15,7 +15,8 @@
 import pytest
 
 from datalake_common import has_s3, DatalakeRecord
-from datalake_common.errors import InsufficientConfiguration
+from datalake_common.errors import InsufficientConfiguration, \
+    UnsupportedTimeRange
 
 
 @pytest.mark.skipif(not has_s3, reason='requires s3 features')
@@ -40,3 +41,12 @@ def test_list_from_metadata(random_metadata):
     assert len(records) >= 1
     for r in records:
         assert r['metadata'] == random_metadata
+
+
+def test_timespan_too_big(random_metadata):
+    url = 's3://foo/blapp'
+    random_metadata['start'] = 0
+    random_metadata['end'] = (DatalakeRecord.MAXIMUM_BUCKET_SPAN + 1) * \
+        DatalakeRecord.TIME_BUCKET_SIZE_IN_MS
+    with pytest.raises(UnsupportedTimeRange):
+        DatalakeRecord.list_from_metadata(url, random_metadata)


### PR DESCRIPTION
We expect this case to come up occasionally when a host boots
with a wildly incorrect clock, causing files created around the
boot time to have wildly incorrect creation times. This is to
work around a notable weakness in our indexing scheme.