### PR TITLE
Config from env

### DIFF
--- a/datalake_common/conf.py
+++ b/datalake_common/conf.py
@@ -11,19 +11,69 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+from dotenv import load_dotenv
+import os
+from .errors import InsufficientConfiguration
 
 
-_conf = {}
+def load_config(config_file, default_config_file, **kwargs):
+    '''load the configuration
+
+    Configuration variables are delivered to applications exclusively through
+    the environment. They get into the environment either from a specified
+    configuration file, from a default configuration file, from an environment
+    variable, or from a kwarg specified to this function.
+
+    Configuration variables are applied with the following precedence (lowest
+    to highest):
+
+    - config file: the format of the config file is a typical environment file
+      with individual lines like DATALAKE_FOO=bar. By convention, all variables
+      start with either DATALAKE_ or AWS_.
+
+    - environment variables: The variable names are the same as what would be
+      written in a config file.
+
+    - kwargs: additional configuration variables to apply, subject to some
+      conventions. Specifically, kwargs are lowercase. A kwarg called `foo`
+      maps to a configuration variable called `DATALAKE_FOO`. The only
+      exception to this is a kwarg that starts with `aws_`. That is, a kwarg
+      called `aws_baz` would map to a configuration variable called `AWS_BAZ`.
 
 
-def get_config():
-    return _conf
+    Args:
+
+    - config_file: the configuration file to load. If it is None,
+      default_config_file will be examined. If it is not None and does not
+      exist an InsufficientConfiguration exception is thrown.
+
+    - default_config_file: the file to try if config_file is None. If
+      default_config_file is None or does not exist, it is simply ignored. No
+      exceptions are thrown.
+
+    - kwargs: key=value pairs.
+
+    '''
+    if config_file and not os.path.exists(config_file):
+        msg = 'config file {} does not exist'.format(config_file)
+        raise InsufficientConfiguration(msg)
+
+    if config_file is None and \
+       default_config_file is not None and \
+       os.path.exists(default_config_file):
+        config_file = default_config_file
+
+    if config_file is not None:
+        load_dotenv(config_file)
+
+    _update_environment(**kwargs)
 
 
-def get_config_var(name):
-    return _conf.get(name)
-
-
-def set_config(conf):
-    global _conf
-    _conf = conf
+def _update_environment(**kwargs):
+    for k, v in kwargs.iteritems():
+        if v is None:
+            continue
+        if not k.startswith('aws_'):
+            k = 'DATALAKE_' + k
+        k = k.upper()
+        os.environ[k] = v

--- a/datalake_common/errors.py
+++ b/datalake_common/errors.py
@@ -19,3 +19,7 @@ class InsufficientConfiguration(Exception):
 
 class UnsupportedTimeRange(Exception):
     pass
+
+
+class NoSuchDatalakeFile(Exception):
+    pass

--- a/datalake_common/record.py
+++ b/datalake_common/record.py
@@ -14,8 +14,8 @@
 
 from datalake_common import Metadata, InvalidDatalakeMetadata
 from urlparse import urlparse
-from conf import get_config_var
 import simplejson as json
+import os
 
 
 from errors import InsufficientConfiguration, UnsupportedTimeRange, \
@@ -117,7 +117,7 @@ class DatalakeRecord(dict):
     @classmethod
     def _prepare_connection(cls):
         kwargs = {}
-        s3_host = get_config_var('s3_host')
+        s3_host = os.environ.get('AWS_S3_HOST')
         if s3_host:
             kwargs['host'] = s3_host
         return boto.connect_s3(**kwargs)

--- a/datalake_common/record.py
+++ b/datalake_common/record.py
@@ -17,7 +17,9 @@ from urlparse import urlparse
 from conf import get_config_var
 import simplejson as json
 
-from errors import InsufficientConfiguration, UnsupportedTimeRange
+
+from errors import InsufficientConfiguration, UnsupportedTimeRange, \
+    NoSuchDatalakeFile
 
 '''whether or not s3 features are available
 
@@ -27,6 +29,7 @@ InsufficientConfiguration.'''
 has_s3 = True
 try:
     import boto.s3
+    from boto.exception import S3ResponseError
 except ImportError:
     has_s3 = False
 
@@ -75,6 +78,10 @@ class DatalakeRecord(dict):
         parsed_url = urlparse(url)
         bucket = cls._get_bucket(parsed_url.netloc)
         key = bucket.get_key(parsed_url.path)
+        if key is None:
+            msg = '{} does not appear to be in the datalake'
+            msg = msg.format(url)
+            raise NoSuchDatalakeFile(msg)
         metadata = key.get_metadata('datalake')
         if not metadata:
             raise InvalidDatalakeMetadata('No datalake metadata for ' + url)
@@ -85,9 +92,19 @@ class DatalakeRecord(dict):
     @classmethod
     def _get_bucket(cls, bucket_name):
         if bucket_name not in cls._BUCKETS:
-            bucket = cls._connection().get_bucket(bucket_name)
+            bucket = cls._get_bucket_from_s3(bucket_name)
             DatalakeRecord._BUCKETS[bucket_name] = bucket
         return cls._BUCKETS[bucket_name]
+
+    @classmethod
+    def _get_bucket_from_s3(cls, bucket_name):
+        try:
+            return cls._connection().get_bucket(bucket_name)
+        except S3ResponseError as e:
+            if e.error_code == 'NoSuchBucket':
+                msg = 'Cannot find datalake file (s3 bucket {} does not exist)'
+                msg = msg.format(bucket_name)
+                raise NoSuchDatalakeFile(msg)
 
     _CONNECTION = None
 

--- a/datalake_common/tests/test_conf.py
+++ b/datalake_common/tests/test_conf.py
@@ -1,0 +1,79 @@
+import pytest
+import os
+from datalake_common.conf import load_config
+from datalake_common.errors import InsufficientConfiguration
+
+
+@pytest.fixture
+def mockenv(monkeypatch):
+    monkeypatch.setattr("os.environ", {})
+
+
+def test_config_file(mockenv, tmpfile):
+    config_vars = [
+        'DATALAKE_FOO=bar',
+    ]
+    conf = tmpfile('\n'.join(config_vars))
+    load_config(conf, None)
+    assert 'DATALAKE_FOO' in os.environ
+    assert os.environ['DATALAKE_FOO'] == 'bar'
+
+
+def test_env_overrides_config(mockenv, tmpfile):
+    os.environ['DATALAKE_FOO'] = 'baz'
+    config_vars = [
+        'DATALAKE_FOO=bar',
+    ]
+    conf = tmpfile('\n'.join(config_vars))
+    load_config(conf, None)
+    assert 'DATALAKE_FOO' in os.environ
+    assert os.environ['DATALAKE_FOO'] == 'baz'
+
+
+def test_kwarg_overrides_all(mockenv, tmpfile):
+    os.environ['DATALAKE_FOO'] = 'baz'
+    config_vars = [
+        'DATALAKE_FOO=bar',
+    ]
+    conf = tmpfile('\n'.join(config_vars))
+    load_config(conf, None, foo='bing')
+    assert 'DATALAKE_FOO' in os.environ
+    assert os.environ['DATALAKE_FOO'] == 'bing'
+
+
+def test_aws_exception(monkeypatch, tmpfile):
+    load_config(None, None, aws_variable='value')
+    assert 'AWS_VARIABLE' in os.environ
+    assert os.environ['AWS_VARIABLE'] == 'value'
+
+
+def test_default_config(mockenv, tmpfile):
+    default_config_vars = [
+        'DATALAKE_FOO=bar',
+    ]
+    default_conf = tmpfile('\n'.join(default_config_vars))
+
+    load_config(None, default_conf)
+    assert 'DATALAKE_FOO' in os.environ
+    assert os.environ['DATALAKE_FOO'] == 'bar'
+
+
+def test_config_overrides_default_config(mockenv, tmpfile):
+    default_config_vars = [
+        'DATALAKE_FOO=bar',
+    ]
+    default_conf = tmpfile('\n'.join(default_config_vars))
+
+    config_vars = [
+        'DATALAKE_FOO=bing',
+    ]
+    conf = tmpfile('\n'.join(config_vars))
+
+    load_config(conf, default_conf)
+    assert 'DATALAKE_FOO' in os.environ
+    assert os.environ['DATALAKE_FOO'] == 'bing'
+
+
+def test_config_does_not_exist(mockenv, tmpfile):
+    with pytest.raises(InsufficientConfiguration):
+        load_config('/no/such/file', None)

--- a/datalake_common/tests/test_record.py
+++ b/datalake_common/tests/test_record.py
@@ -16,7 +16,7 @@ import pytest
 
 from datalake_common import has_s3, DatalakeRecord
 from datalake_common.errors import InsufficientConfiguration, \
-    UnsupportedTimeRange
+    UnsupportedTimeRange, NoSuchDatalakeFile
 
 
 @pytest.mark.skipif(not has_s3, reason='requires s3 features')
@@ -50,3 +50,18 @@ def test_timespan_too_big(random_metadata):
         DatalakeRecord.TIME_BUCKET_SIZE_IN_MS
     with pytest.raises(UnsupportedTimeRange):
         DatalakeRecord.list_from_metadata(url, random_metadata)
+
+
+@pytest.mark.skipif(not has_s3, reason='requires s3 features')
+def test_no_such_datalake_file_in_bucket(s3_bucket_maker):
+    s3_bucket_maker('test-bucket')
+    url = 's3://test-bucket/such/file'
+    with pytest.raises(NoSuchDatalakeFile):
+        DatalakeRecord.list_from_url(url)
+
+
+@pytest.mark.skipif(not has_s3, reason='requires s3 features')
+def test_no_such_bucket(s3_connection):
+    url = 's3://no/such/file'
+    with pytest.raises(NoSuchDatalakeFile):
+        DatalakeRecord.list_from_url(url)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name='datalake-common',
           'pytz>=2015.4',
           'pyver>=1.0.18',
           'simplejson>=3.3.1',
+          'python-dotenv>=0.1.3',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
This is a step towards normalizing how we handle config in the datalake parts. Specifically, consumers of config information should just get their config from environment variables. Producers of config information should either pass these details in to the relevant constructors or set environment variables. The load_config function is meant as a helper to do the right thing when config may come from either command line args (er, kwargs), the environment, or a config file.