### PR TITLE
tolerate metadata without end

### DIFF
--- a/datalake_common/record.py
+++ b/datalake_common/record.py
@@ -146,7 +146,7 @@ class DatalakeRecord(dict):
     def get_time_buckets_from_metadata(metadata):
         '''return a list of time buckets in which the metadata falls'''
         start = metadata['start']
-        end = metadata['end'] or start
+        end = metadata.get('end') or start
         buckets = DatalakeRecord.get_time_buckets(start, end)
         if len(buckets) > DatalakeRecord.MAXIMUM_BUCKET_SPAN:
             msg = 'metadata spans too many time buckets: {}'

--- a/datalake_common/tests/test_record.py
+++ b/datalake_common/tests/test_record.py
@@ -65,3 +65,12 @@ def test_no_such_bucket(s3_connection):
     url = 's3://no/such/file'
     with pytest.raises(NoSuchDatalakeFile):
         DatalakeRecord.list_from_url(url)
+
+
+def test_no_end(random_metadata):
+    url = 's3://foo/baz'
+    del(random_metadata['end'])
+    records = DatalakeRecord.list_from_metadata(url, random_metadata)
+    assert len(records) >= 1
+    for r in records:
+        assert r['metadata'] == random_metadata


### PR DESCRIPTION
This is allowed per the data contract in the README. So there.