### PR TITLE
support files originating from windows machines

### DIFF
--- a/datalake_common/metadata.py
+++ b/datalake_common/metadata.py
@@ -45,6 +45,9 @@ class UnsupportedDatalakeMetadataVersion(Exception):
 _EPOCH = datetime.fromtimestamp(0, utc)
 
 
+_WINDOWS_ABS_PATH = re.compile(r'^[a-zA-Z]:\\.+')
+
+
 class Metadata(dict):
 
     _VERSION = 0
@@ -148,9 +151,13 @@ class Metadata(dict):
             raise InvalidDatalakeMetadata(msg)
 
     def _validate_path(self):
-        if not os.path.isabs(self['path']):
+        if not os.path.isabs(self['path']) and \
+           not self._is_windows_abs(self['path']):
             msg = '{} is not an absolute path.'.format(self['path'])
             raise InvalidDatalakeMetadata(msg)
+
+    def _is_windows_abs(self, path):
+        return _WINDOWS_ABS_PATH.match(path) is not None
 
     def _validate_interval(self):
         if self.get('end') is None:

--- a/datalake_common/tests/test_metadata.py
+++ b/datalake_common/tests/test_metadata.py
@@ -168,3 +168,37 @@ def test_normalize_date_with_datetime(basic_metadata):
 def test_normalize_garbage(basic_metadata):
     with pytest.raises(InvalidDatalakeMetadata):
         Metadata.normalize_date('bleeblaaablooo')
+
+
+def test_path_with_leading_dot_not_allowed(basic_metadata):
+    basic_metadata['path'] = './abc.txt'
+    with pytest.raises(InvalidDatalakeMetadata):
+        Metadata(basic_metadata)
+
+
+def test_relative_path_not_allowed(basic_metadata):
+    basic_metadata['path'] = 'abc.txt'
+    with pytest.raises(InvalidDatalakeMetadata):
+        Metadata(basic_metadata)
+
+
+def test_absolute_windows_path(basic_metadata):
+    path = r'Z:\\foo\bar.txt'
+    basic_metadata['path'] = path
+    m = Metadata(basic_metadata)
+    assert m['path'] == path
+
+
+def test_absolute_windows_path_single_slash(basic_metadata):
+    # some cygwin environments seem to have a single slash after the
+    # drive. Shrug.
+    path = r'Z:\foo\bar.txt'
+    basic_metadata['path'] = path
+    m = Metadata(basic_metadata)
+    assert m['path'] == path
+
+
+def test_relative_windows_path_not_allowed(basic_metadata):
+    basic_metadata['path'] = r'foo\abc.txt'
+    with pytest.raises(InvalidDatalakeMetadata):
+        Metadata(basic_metadata)


### PR DESCRIPTION
Some users push files from a cygwin/windows environment. On these
platforms, windows paths appear to be legit absolute paths. And
so creating valid metadata for these files works. But once the
metadata appears over on the linux-based ingester or API server,
these appear invalid. This patch makes the latter tolerate
absolute windows paths. Note that it will not make hypothetical
windows-based ingesters and web machines tolerate absolute unix
paths.