### PR TITLE
Metadata end key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ the epoch. Alternatively, if the file is associated with an instant, this is
 the only relevant time. It is required.
 
 end: This is the time of the last event in the file in milliseconds since the
-epoch. If it is not present, the file represents a snapshot of something like a
-weekly report.
+epoch. If the key is not present or if the value is `None`, the file represents a
+snapshot of something like a weekly report where only one date (`start`) is
+relevant.
 
 path: The absolute path to the file in the originating filesystem.
 

--- a/datalake_common/metadata.py
+++ b/datalake_common/metadata.py
@@ -42,6 +42,7 @@ class InvalidDatalakeMetadata(Exception):
 class UnsupportedDatalakeMetadataVersion(Exception):
     pass
 
+
 _EPOCH = datetime.fromtimestamp(0, utc)
 
 
@@ -160,9 +161,10 @@ class Metadata(dict):
         return _WINDOWS_ABS_PATH.match(path) is not None
 
     def _validate_interval(self):
-        if self.get('end') is None:
+        end_val = self['end']
+        if end_val is None:
             return
-        if self['end'] < self['start']:
+        if end_val < self['start']:
             msg = '"end" must be greater than "start"'
             raise InvalidDatalakeMetadata(msg)
 
@@ -171,10 +173,9 @@ class Metadata(dict):
         self._normalize_end()
 
     def _normalize_end(self):
-        if 'end' not in self:
-            return
-        if self['end'] is not None:
-            self['end'] = self.normalize_date(self['end'])
+        end_val = self.setdefault('end', None)
+        if end_val is not None:
+            self['end'] = self.normalize_date(end_val)
 
     @staticmethod
     def normalize_date(date):

--- a/datalake_common/tests/test_metadata.py
+++ b/datalake_common/tests/test_metadata.py
@@ -72,7 +72,7 @@ def test_id_not_overwritten(basic_metadata):
 def test_no_end_allowed(basic_metadata):
     del(basic_metadata['end'])
     m = Metadata(basic_metadata)
-    assert 'end' not in m
+    assert m['end'] is None
 
 
 def test_unallowed_characters(basic_metadata):

--- a/datalake_common/tests/test_record.py
+++ b/datalake_common/tests/test_record.py
@@ -76,11 +76,13 @@ def test_no_such_bucket(s3_connection):
 def test_no_end(random_metadata, s3_file_from_metadata):
     url = 's3://foo/baz'
     del(random_metadata['end'])
+    expected_metadata = random_metadata.copy()
+    expected_metadata['end'] = None
     s3_file_from_metadata(url, random_metadata)
     records = DatalakeRecord.list_from_metadata(url, random_metadata)
     assert len(records) >= 1
     for r in records:
-        assert r['metadata'] == random_metadata
+        assert r['metadata'] == expected_metadata
 
 
 def test_get_time_buckets_misaligned():


### PR DESCRIPTION
For @bcavagnolo 
cc @dtkav 

If there's no end key in the metadata, add one and make the value default to `None`

This handles our missing end key issue. Fixing it here may be preferable to patching downstream in the datalake-api or in MC.

